### PR TITLE
Fix code scanning alert no. 5: Use of password hash with insufficient computational effort

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -63,7 +63,8 @@
     "ms": "^2.1.3",
     "node-rsa": "^1.1.1",
     "omit.js": "^2.0.2",
-    "reflect-metadata": "^0.2.2"
+    "reflect-metadata": "^0.2.2",
+    "bcrypt": "^5.1.1"
   },
   "packageManager": "pnpm@9.11.0"
 }

--- a/packages/backend/src/services/authService.ts
+++ b/packages/backend/src/services/authService.ts
@@ -18,7 +18,7 @@ export class AuthService {
       LogUtils.debug(`User [${username}] not found`);
       return null;
     }
-    const digestPassword = SHAUtils.digest(password);
+    const digestPassword = await SHAUtils.digest(password);
     if (user.password !== digestPassword) {
       LogUtils.debug(`Password [${username}:${password}] not match`);
       return null;

--- a/packages/backend/src/utils/SHAUtils.ts
+++ b/packages/backend/src/utils/SHAUtils.ts
@@ -1,7 +1,8 @@
-import { createHash } from "crypto";
+import * as bcrypt from "bcrypt";
 
 export class SHAUtils {
-  static digest(data: string): string {
-    return createHash("sha256").update(data).digest("base64");
+  static async digest(data: string): Promise<string> {
+    const saltRounds = 10;
+    return await bcrypt.hash(data, saltRounds);
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/Cyrusky/blog/security/code-scanning/5](https://github.com/Cyrusky/blog/security/code-scanning/5)

To fix the problem, we need to replace the insecure `sha256` hashing with a more secure password hashing algorithm like `bcrypt`. This change will ensure that the password hashing process is computationally intensive, making it more resistant to brute-force attacks.

1. **General Fix Approach:**
   - Replace the `sha256` hashing function with `bcrypt`.
   - Update the relevant imports and method calls to use `bcrypt`.

2. **Detailed Fix:**
   - Modify the `SHAUtils` class to use `bcrypt` for hashing passwords.
   - Update the `AuthService` class to use the new `bcrypt` hashing method.

3. **Specific Changes:**
   - Update `packages/backend/src/utils/SHAUtils.ts` to use `bcrypt`.
   - Update `packages/backend/src/services/authService.ts` to use the new hashing method from `SHAUtils`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
